### PR TITLE
Add async model downloading with Tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = {version = "^0.12.15", features = ["blocking"]}
 num-traits = "0.2.19"
 log = "0.4.27"
 imageproc = "^0.25.0"
+tokio = { version = "1.45.0", features = ["fs", "rt-multi-thread"] }
 
 [features]
 default = ["download-binaries", "chinese_click_0", "slide_0"]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -3,12 +3,12 @@ use ort::execution_providers::{CPUExecutionProvider, ExecutionProviderDispatch};
 use ort::session::Session;
 use reqwest::Url;
 use std::error::Error;
-use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::{env, fs};
-use image::EncodableLayout;
-
+use tokio::fs::File as TokioFile;
+use tokio::io::AsyncWriteExt;
+use std::time::Duration;
 
 pub enum ModelLoader {
     DefaultModelLoader,
@@ -25,22 +25,88 @@ pub trait ModelLoaderTrait {
 pub struct DefaultModelLoader;
 
 fn load_one_model(path: &Path, url: &Url, providers: impl IntoIterator<Item = ExecutionProviderDispatch>) -> Result<Session, Box<dyn Error>> {
-    let bytes;
+    let model_bytes: Vec<u8>;
+
     if !path.exists() {
-        let client = reqwest::blocking::Client::builder()
-            .user_agent("CaptchaBreaker")
+        println!("Model not found locally. Downloading from {} to {}...", url.as_str(), path.display());
+        
+        // 创建一个 Tokio 运行时来执行异步下载
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
             .build()?;
-        bytes = client.get(url.as_str()).send()?.bytes()?.as_bytes().to_owned();
-        let mut file = File::create(path)?;
-        file.write_all(bytes.as_ref())?;
+
+        // 在 Tokio 运行时中阻塞执行异步下载逻辑
+        model_bytes = rt.block_on(async {
+            download_model_streaming_internal(url, path).await
+        })?;
+        println!("Model downloaded successfully to {}.", path.display());
+        
 
     } else {
-        bytes = fs::read(path)?;
+        println!("Loading model from local cache: {}.", path.display());
+        model_bytes = fs::read(path)?; // std::fs::read
     }
     Ok(Session::builder()?
         .with_execution_providers(providers)?
-        .commit_from_memory(bytes.as_ref())?)
+        .commit_from_memory(model_bytes.as_ref())?)
 }
+
+// 异步流式下载函数
+async fn download_model_streaming_internal(url: &Url, file_path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
+    let client = reqwest::Client::builder()
+        .user_agent("CaptchaBreaker")
+        .timeout(Duration::from_secs(3600)) // 1h超时
+        .build()?;
+
+    let mut response = client.get(url.clone()).send().await?;
+
+    if !response.status().is_success() {
+        return Err(format!("Request failed with status: {}", response.status()).into());
+    }
+
+    // 确保目标目录存在
+    if let Some(parent_dir) = file_path.parent() {
+        if !parent_dir.exists() {
+            tokio::fs::create_dir_all(parent_dir).await?;
+        }
+    }
+
+    // 使用临时文件下载，成功后再重命名，避免下载中断导致文件损坏
+    let temp_file_path_str = format!("{}.tmp", file_path.to_string_lossy());
+    let temp_file_path = Path::new(&temp_file_path_str);
+
+    let mut dest_file = TokioFile::create(&temp_file_path).await?;
+    let mut downloaded_bytes: u64 = 0;
+    let total_size = response.content_length().unwrap_or(0);
+    let mut all_bytes_for_session = Vec::new();
+
+    println!("Starting streaming download...");
+    while let Some(chunk) = response.chunk().await? {
+        dest_file.write_all(&chunk).await?;
+        all_bytes_for_session.extend_from_slice(&chunk);
+        downloaded_bytes += chunk.len() as u64;
+        if total_size > 0 {
+            print!("\rDownloaded {:.2} / {:.2} MB ({:.2}%)", 
+                  downloaded_bytes as f64 / 1_048_576.0, 
+                  total_size as f64 / 1_048_576.0, 
+                  (downloaded_bytes as f64 * 100.0) / total_size as f64);
+        } else {
+            print!("\rDownloaded {:.2} MB", downloaded_bytes as f64 / 1_048_576.0);
+        }
+        std::io::stdout().flush()?;
+    }
+    println!("\nDownload stream complete!");
+    dest_file.flush().await?; // 确保所有数据都写入磁盘
+    drop(dest_file);
+
+    // 下载成功后，将临时文件重命名为目标文件
+    tokio::fs::rename(&temp_file_path, file_path).await?;
+    println!("Temporary file renamed to {}", file_path.display());
+
+    Ok(all_bytes_for_session) // 返回下载的所有字节
+}
+
+
 impl ModelLoaderTrait for DefaultModelLoader {
     fn load_with_execution_providers(&self, model: Model, providers: Vec<ExecutionProviderDispatch>) -> Result<Session, Box<dyn Error>> {
         let root = env::current_dir()?;
@@ -51,16 +117,12 @@ impl ModelLoaderTrait for DefaultModelLoader {
         match model {
             Model::Yolo11n => load_one_model(
                 model_root.join("yolov11n_captcha.onnx").as_path(),
-                &Url::parse(
-                    "https://www.modelscope.cn/models/Amorter/CaptchaBreakerModels/resolve/master/yolov11n_captcha.onnx",
-                )?,
+                &Url::parse("https://www.modelscope.cn/models/Amorter/CaptchaBreakerModels/resolve/master/yolov11n_captcha.onnx", )?,
                 providers,
             ),
             Model::Siamese => load_one_model(
                 model_root.join("siamese.onnx").as_path(),
-                &Url::parse(
-                    "https://www.modelscope.cn/models/Amorter/CaptchaBreakerModels/resolve/master/siamese.onnx",
-                )?,
+                &Url::parse("https://www.modelscope.cn/models/Amorter/CaptchaBreakerModels/resolve/master/siamese.onnx", )?,
                 providers,
             ),
         }


### PR DESCRIPTION
实现异步流式下载以避免网络环境较差时的网络超时等各种问题。
包含了一些详细信息和下载进度的输出，可按需调整或删除。